### PR TITLE
fix: write to file encoding error

### DIFF
--- a/app/libs/utils.py
+++ b/app/libs/utils.py
@@ -17,7 +17,7 @@ def get_page_content(driver, url):
     return soup
 
 def write_file(output, file_name):
-    with open(f'static/{file_name}', 'w') as f:
+    with open(f'static/{file_name}', 'w', encoding='utf-8') as f:
         f.write(output)
         return True
 


### PR DESCRIPTION
hi 寫檔時會有以下error 

  File "C:rent-crawlers\app\libs\utils.py", line 21, in write_file
    f.write(output)
UnicodeEncodeError: 'cp950' codec can't encode character '\U0001f3e1' in position 23710: illegal multibyte sequence

這是常見問題，所以開檔時應該指定為 'utf-8' 避免此問題